### PR TITLE
fix: Fix flight filter functionality issues

### DIFF
--- a/frontend/src/pages/Flights/FlightsResultsPage.jsx
+++ b/frontend/src/pages/Flights/FlightsResultsPage.jsx
@@ -95,6 +95,19 @@ const FlightsResultsPage = () => {
   const [filterModel, setFilterModel] = useState('')
   const [filterCabin, setFilterCabin] = useState('')
 
+  // 初始化时清除 URL 中的筛选参数，保留搜索参数
+  useEffect(() => {
+    const params = new URLSearchParams(location.search)
+    const hasFilters = params.has('airline') || params.has('timeSlot') || params.has('model') || params.has('cabin')
+    if (hasFilters) {
+      params.delete('airline')
+      params.delete('timeSlot')
+      params.delete('model')
+      params.delete('cabin')
+      navigate(`/flights/results?${params.toString()}`, { replace: true })
+    }
+  }, []) // 只在组件挂载时执行一次
+
   useEffect(() => {
     const t = setTimeout(async () => {
       const q = fromInput.trim()


### PR DESCRIPTION
## 🐛 Bug Fixes

This PR fixes two critical bugs in the flight search results page related to the filter functionality.

### Bug #1: Filter requires double-click to take effect
**Problem:**
- Users had to click filter options twice for them to take effect
- First click had no visible result, second click would apply the first selection

**Root Cause:**
- React's `setState` is asynchronous
- `applyParams` function was using stale state values when called immediately after `setState`

**Solution:**
- Modified `applyParams` to accept an `overrides` parameter
- Filter click handlers now pass new values directly instead of relying on state updates
- Uses immediate values as priority, state values as fallback

**Affected Filters:**
- ✅ Airlines
- ✅ Departure/Arrival time
- ✅ Aircraft model
- ✅ Cabin class

### Bug #2: Filters persist after page refresh
**Problem:**
- After applying filters and refreshing the page, the filters remained active
- Expected behavior: page refresh should reset all filters

**Root Cause:**
- Filter parameters stored in URL query params (airline, timeSlot, model, cabin)
- URL params persist across page refreshes
- Backend returns filtered results based on URL params

**Solution:**
- Added initialization effect to detect and remove filter params from URL on mount
- Preserves search params (from, to, departDate, returnDate)
- Uses `replace: true` to avoid polluting browser history
- Executes only once on component mount (empty dependency array)

## 🧪 Testing

### Test Bug #1 Fix:
1. Navigate to flight search results page
2. Click any filter option (airline, time, model, or cabin)
3. ✅ Filter should apply immediately without requiring a second click

### Test Bug #2 Fix:
1. Navigate to flight search results page
2. Apply any filter
3. Refresh the page (F5 or Cmd+R)
4. ✅ All filters should be cleared, showing unfiltered results

## 📦 Changes

- Modified `frontend/src/pages/Flights/FlightsResultsPage.jsx`
  - Updated `applyParams` function signature to accept overrides
  - Modified all filter click handlers to pass values directly
  - Added initialization effect to clear filter params on mount

## 📊 Commits

- `1c70a057` - fix: Fix filter requiring double-click
- `7594b3e2` - fix: Fix filters persisting after page refresh

## 🔗 Related Issues

Closes #5